### PR TITLE
Local/remote inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ export async function writeToFile(report: Report, filename: string) {
 
   if (filename.endsWith('.png')) {
     console.log(`This is a PNG! We'll have to compile imagemagick!`)
-    const magick = await npxImport('imagemagick-utils@^1.1.0')
+    const { default: magick } = await npxImport('imagemagick-utils@^1.1.0')
     await magick.renderToPNG(report, filename)
 
   } else if (filename.endsWith('.pdf')) {
     console.log(`Argh, a PDF!? Go make a cuppa, this'll take a while...`)
-    const pdfBoi = await npxImport('chonk-pdf-boi@3.1.4')
+    const { default: pdfBoi } = await npxImport('chonk-pdf-boi@3.1.4')
     await pdfBoi.generate(report, filename)
 
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,6 @@ export async function npxImport<T = unknown>(
         packages[pkg.name].imported = await _importRelative(installDir, pkg.packageWithPath)
         INSTALL_CACHE[pkg.name] = installDir
       }
-      for (const pkg of localPackages) {
-        INSTALL_CACHE[pkg.name] = INSTALLED_LOCALLY
-      }
     } catch (e) {
       throw new Error(
         `npx-import failed for ${missingPackages
@@ -58,6 +55,9 @@ export async function npxImport<T = unknown>(
           `\n\n`
       )
     }
+  }
+  for (const pkg of localPackages) {
+    INSTALL_CACHE[pkg.name] = INSTALLED_LOCALLY
   }
 
   const results = allPackages.map((p) => p.imported)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ export async function _import(packageWithPath: string) {
 }
 
 export async function _importRelative(installDir: string, packageWithPath: string) {
-  return await createRequire(installDir)(packageWithPath)
+  return await import(_resolveRelative(installDir, packageWithPath))
 }
 
 export function _resolve(packageWithPath: string) {


### PR DESCRIPTION
One was just a dumb bug on my part, the other was a bit more pernicious.

Previously I was doing:

```ts
export async function _importRelative(installDir: string, packageWithPath: string) {
  return await createRequire(installDir)(packageWithPath)
}
```

but that uses CJS-style imports (i.e. exports `default` plus named)

```ts
export async function _importRelative(installDir: string, packageWithPath: string) {
  return await import(_resolveRelative(installDir, packageWithPath))
}
```

`import()` _always_ returns an object, as per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#return_value

> It returns a promise which fulfills to an object containing all exports from moduleName, with the same shape as a namespace import (`import * as name from moduleName`): an object with null prototype, and the default export available as a key named `default`.

Changed some of the examples in the readme too.